### PR TITLE
Adjust defaults for US-centric scheduling

### DIFF
--- a/components/chart.py
+++ b/components/chart.py
@@ -10,8 +10,9 @@ except ModuleNotFoundError:
 
 def render_gantt(gdf):
     color_map = {
-        "Core&Shell": colors.MANO_BLUE,
-        "Fitout": colors.FITOUT_COLOR,
+        "Shell": colors.MANO_BLUE,
+        "MEP Yard": colors.MANO_GREY,
+        "Fitup": colors.FITOUT_COLOR,
         "L3": colors.L3_COLOR,
         "L4": colors.L4_COLOR,
         "L5": colors.L5_COLOR,

--- a/utils/building.py
+++ b/utils/building.py
@@ -45,7 +45,7 @@ def get_modeled_equipment_rows(b, ww, holidays):
         else:
             for i, h in enumerate(b["halls"], start=1):
                 ideal = date_utils.add_workdays(h["L3Start"], -buf, holidays, workdays_per_week=ww)
-                roj_h = date_utils.clamp(ideal, h["FitoutStart"], h["FitoutFinish"])
+                roj_h = date_utils.clamp(ideal, h["FitupStart"], h["FitupFinish"])
                 total_wd = (submittals_wd or 0) + (mfg_wd or 0) + (ship_wd or 0)
                 release_h = date_utils.add_workdays(roj_h, -total_wd, holidays, workdays_per_week=ww) if roj_h else None
                 rows.append({


### PR DESCRIPTION
## Summary
- lock the holiday calendar to United States defaults and update building presets to eight 16.8 MW halls
- retime site, shell, MEP yard, and hall fitup workflows so shell begins 80 working days after site start, MEP yard runs finish-to-finish with shell, and fitup follows 40 days after MEP yard start
- refresh commissioning logic (SS+5 for L3, sequential L4/L5) and update the timeline, tables, and equipment modeling to reflect the new Fitup terminology

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c9defedc388323b8743a406fd70b88