### PR TITLE
Add power tranche scheduling and update OFCI equipment modeling

### DIFF
--- a/data/equipment.py
+++ b/data/equipment.py
@@ -1,18 +1,54 @@
-
-# ======================= Built-in Equipment (from your table) =======================
+# ======================= Client-specific OFCI equipment =======================
+# Each entry captures the assumed lead time in working days along with the
+# release "back off" (how many working days away from the anchor milestone the
+# PO should be placed).  Buffers represent the desired cushion ahead of L3.
 RAW_EQUIPMENT = [
-    {"Equipment":"Air Cooled Chiller",               "scope":"house", "PO":"10/1/2025",  "FabStart":"10/23/2025", "ExpectedShip":"4/30/2026", "Delivered":"5/20/2026", "buffer_wd_before_L3":30},
-    {"Equipment":"Computer Room Air Conditioner",    "scope":"hall",  "PO":"8/11/2025",  "FabStart":"9/1/2025",  "ExpectedShip":"3/23/2026", "Delivered":"4/13/2026", "buffer_wd_before_L3":15},
-    {"Equipment":"Generator",                        "scope":"house", "PO":"2/14/2025",  "FabStart":"6/13/2025", "ExpectedShip":"4/28/2026", "Delivered":"5/18/2026", "buffer_wd_before_L3":30},
-    {"Equipment":"Main Switchboard",                 "scope":"house", "PO":"8/4/2025",   "FabStart":"8/25/2025", "ExpectedShip":"2/23/2026", "Delivered":"3/16/2026", "buffer_wd_before_L3":30},
-    {"Equipment":"Maintenance Bypass Board",         "scope":"house", "PO":"8/4/2025",   "FabStart":"8/25/2025", "ExpectedShip":"3/2/2026",  "Delivered":"3/23/2026", "buffer_wd_before_L3":30},
-    {"Equipment":"Mechanical Panels",                "scope":"house", "PO":"9/2/2025",   "FabStart":"9/23/2025", "ExpectedShip":"6/23/2026", "Delivered":"7/14/2026", "buffer_wd_before_L3":30},
-    {"Equipment":"Modular Electrical Room",          "scope":"house", "PO":"8/11/2025",  "FabStart":"11/10/2025","ExpectedShip":"7/21/2026", "Delivered":"7/27/2026", "buffer_wd_before_L3":30},
-    {"Equipment":"Padmount Transformer",             "scope":"house", "PO":"6/17/2025",  "FabStart":"7/8/2025",  "ExpectedShip":"12/9/2025", "Delivered":"1/20/2026", "buffer_wd_before_L3":30},
-    {"Equipment":"Power Distribution Unit",          "scope":"hall",  "PO":"8/11/2025",  "FabStart":"9/1/2025",  "ExpectedShip":"6/29/2026", "Delivered":"7/20/2026", "buffer_wd_before_L3":15},
-    {"Equipment":"Static Transfer Switch",           "scope":"hall",  "PO":"8/11/2025",  "FabStart":"9/1/2025",  "ExpectedShip":"5/4/2026",  "Delivered":"5/25/2026", "buffer_wd_before_L3":15},
-    {"Equipment":"Uninterruptible Power Supply",     "scope":"hall",  "PO":"8/11/2025",  "FabStart":"9/1/2025",  "ExpectedShip":"6/16/2026", "Delivered":"6/30/2026", "buffer_wd_before_L3":15},
-    {"Equipment":"UPS Battery Cabinet",              "scope":"hall",  "PO":"8/12/2025",  "FabStart":"9/2/2025",  "ExpectedShip":"3/31/2026", "Delivered":"4/14/2026", "buffer_wd_before_L3":15},
-    {"Equipment":"UPS Board",                        "scope":"hall",  "PO":"8/4/2025",   "FabStart":"8/25/2025", "ExpectedShip":"3/16/2026", "Delivered":"4/6/2026",  "buffer_wd_before_L3":15},
-    {"Equipment":"UPS Board Reserve",                "scope":"hall",  "PO":"8/4/2025",   "FabStart":"8/25/2025", "ExpectedShip":"3/16/2026", "Delivered":"4/6/2026",  "buffer_wd_before_L3":15},
+    {
+        "Equipment": "Generators",
+        "scope": "house",
+        "lead_time_wd": 320,
+        "buffer_wd_before_L3": 30,
+        "release_anchor": "ntp",
+        "release_offset_wd": 150,
+    },
+    {
+        "Equipment": "Utility Switchgear",
+        "scope": "house",
+        "lead_time_wd": 240,
+        "buffer_wd_before_L3": 30,
+        "release_anchor": "ntp",
+        "release_offset_wd": 200,
+    },
+    {
+        "Equipment": "UPS",
+        "scope": "hall",
+        "lead_time_wd": 270,
+        "buffer_wd_before_L3": 20,
+        "release_anchor": "bp",
+        "release_offset_wd": 105,
+    },
+    {
+        "Equipment": "PDU",
+        "scope": "hall",
+        "lead_time_wd": 225,
+        "buffer_wd_before_L3": 20,
+        "release_anchor": "fitup_start",
+        "release_offset_wd": -60,
+    },
+    {
+        "Equipment": "CRAC",
+        "scope": "hall",
+        "lead_time_wd": 210,
+        "buffer_wd_before_L3": 20,
+        "release_anchor": "fitup_start",
+        "release_offset_wd": -60,
+    },
+    {
+        "Equipment": "BMS",
+        "scope": "hall",
+        "lead_time_wd": 180,
+        "buffer_wd_before_L3": 25,
+        "release_anchor": "fitup_start",
+        "release_offset_wd": -90,
+    },
 ]

--- a/utils/building.py
+++ b/utils/building.py
@@ -1,63 +1,157 @@
 import utils.date as date_utils
 import data.equipment as equipment
 
-# ======================= Procurement model (submittals + mfg + shipping) =======================
+
+def _max_date(*dates):
+    valid = [d for d in dates if d is not None]
+    return max(valid) if valid else None
+
+
+def _min_date(*dates):
+    valid = [d for d in dates if d is not None]
+    return min(valid) if valid else None
+
+
+def _format_anchor(anchor, offset):
+    if not anchor:
+        return None
+    label = anchor.replace("_", " ").title()
+    if offset in (None, 0):
+        return label
+    sign = "+" if offset >= 0 else "-"
+    return f"{label} {sign}{abs(int(offset))} wd"
+
+
+def _resolve_anchor_date(anchor, building, hall):
+    if not anchor:
+        return None
+    anchor = anchor.lower()
+    gates = building.get("gates", {}) if isinstance(building.get("gates"), dict) else {}
+
+    if anchor == "ntp":
+        return gates.get("ntp")
+    if anchor == "ldp":
+        return gates.get("ldp")
+    if anchor == "bp":
+        return gates.get("bp")
+    if anchor in ("perm_power", "permanent_power"):
+        return building.get("perm_power")
+    if anchor == "dryin":
+        return building.get("dryin_date")
+    if anchor == "shell_start":
+        return building.get("shell_start")
+    if anchor == "shell_finish":
+        return building.get("shell_finish")
+    if anchor == "civil_start":
+        return building.get("civil_start")
+    if anchor == "mep_start":
+        return building.get("mep_start")
+    if anchor == "mep_finish":
+        return building.get("mep_finish")
+    if anchor in ("fitup_start", "hall_fit_start"):
+        if hall:
+            return hall.get("FitupStart")
+        return building.get("halls", [{}])[0].get("FitupStart") if building.get("halls") else None
+    if anchor in ("fitup_finish", "hall_fit_finish"):
+        if hall:
+            return hall.get("FitupFinish")
+        return building.get("halls", [{}])[0].get("FitupFinish") if building.get("halls") else None
+    if anchor in ("l3_start", "hall_l3_start"):
+        if hall:
+            return hall.get("L3Start")
+        return building.get("halls", [{}])[0].get("L3Start") if building.get("halls") else None
+    if anchor == "power_gate" and hall:
+        return hall.get("PowerGate")
+    if anchor == "power_delivery" and hall:
+        return hall.get("PowerDeliveryDate")
+    return None
+
+
+def _add_offset(base, offset, holidays, ww):
+    if base is None:
+        return None
+    if offset in (None, 0):
+        return base
+    return date_utils.add_workdays(base, int(offset), holidays, workdays_per_week=ww)
+
+
+# ======================= Procurement model (lead time + back off) =======================
 def get_modeled_equipment_rows(b, ww, holidays):
     rows = []
+    first_hall = b["halls"][0] if b.get("halls") else None
+
     for item in equipment.RAW_EQUIPMENT:
-        po = date_utils.to_date(item.get("PO"))
-        fab = date_utils.to_date(item.get("FabStart"))
-        ship = date_utils.to_date(item.get("ExpectedShip"))
-        delivered = date_utils.to_date(item.get("Delivered"))
+        lead_wd = int(item.get("lead_time_wd") or 0)
+        buffer_wd = int(item.get("buffer_wd_before_L3") or 0)
+        offset_wd = item.get("release_offset_wd")
+        anchor_key = item.get("release_anchor")
+        anchor_label = _format_anchor(anchor_key, offset_wd)
 
-        submittals_wd = date_utils.workdays_between(po, fab, ww, holidays) if po and fab else None
-        if submittals_wd is None: submittals_wd = 20
-        submittals_wd = max(15, min(submittals_wd, 45))
-
-        mfg_wd = date_utils.workdays_between(fab, ship, ww, holidays) if fab and ship else None
-        ship_wd = date_utils.workdays_between(ship, delivered, ww, holidays) if ship and delivered else 15
-
-        arrival = None
-        if po:
-            arrival = date_utils.add_workdays(po, submittals_wd, holidays, workdays_per_week=ww)
-            if mfg_wd: arrival = date_utils.add_workdays(arrival, mfg_wd, holidays, workdays_per_week=ww)
-            if ship_wd: arrival = date_utils.add_workdays(arrival, ship_wd, holidays, workdays_per_week=ww)
-
-        buf = int(item["buffer_wd_before_L3"])
         if item["scope"] == "house":
-            anchor = b["halls"][0]["L3Start"]
-            ideal = date_utils.add_workdays(anchor, -buf, holidays, workdays_per_week=ww)
-            roj = date_utils.clamp(ideal, b["dryin_date"], None)
-            total_wd = (submittals_wd or 0) + (mfg_wd or 0) + (ship_wd or 0)
-            release = date_utils.add_workdays(roj, -total_wd, holidays, workdays_per_week=ww) if roj else None
+            anchor_date = _resolve_anchor_date(anchor_key, b, None)
+            release_plan = _add_offset(anchor_date, offset_wd, holidays, ww)
+
+            desired = None
+            if first_hall and first_hall.get("L3Start"):
+                ideal = first_hall["L3Start"]
+                if buffer_wd:
+                    ideal = date_utils.add_workdays(ideal, -buffer_wd, holidays, workdays_per_week=ww)
+                desired = date_utils.clamp(ideal, b.get("dryin_date"), None)
+
+            release_needed = date_utils.add_workdays(desired, -lead_wd, holidays, workdays_per_week=ww) if (desired and lead_wd) else None
+            release_used = _min_date(release_plan, release_needed) if (release_plan or release_needed) else release_plan or release_needed
+            site_accept = date_utils.add_workdays(release_used, lead_wd, holidays, workdays_per_week=ww) if (release_used and lead_wd) else release_used
+
+            roj = desired
+            if site_accept and (roj is None or site_accept > roj):
+                roj = site_accept
+            if roj and b.get("dryin_date") and roj < b["dryin_date"]:
+                roj = b["dryin_date"]
+
             rows.append({
                 "Building Name": b["building_name"],
                 "Equipment": item["Equipment"],
                 "Location": "House",
-                "Required Release/PO": release,
-                "Submittals (days)": submittals_wd,
-                "Manufacturing (days)": mfg_wd,
-                "Shipping (days)": ship_wd,
-                "Site Acceptance": arrival,
+                "Release Anchor": anchor_label,
+                "Release Plan": release_plan,
+                "Release Needed": release_needed,
+                "Modeled Release": release_used,
+                "Lead Time (wd)": lead_wd,
+                "Site Acceptance": site_accept,
+                "ROJ Target": desired,
                 "ROJ": roj,
-
             })
         else:
-            for i, h in enumerate(b["halls"], start=1):
-                ideal = date_utils.add_workdays(h["L3Start"], -buf, holidays, workdays_per_week=ww)
-                roj_h = date_utils.clamp(ideal, h["FitupStart"], h["FitupFinish"])
-                total_wd = (submittals_wd or 0) + (mfg_wd or 0) + (ship_wd or 0)
-                release_h = date_utils.add_workdays(roj_h, -total_wd, holidays, workdays_per_week=ww) if roj_h else None
+            for idx, hall in enumerate(b.get("halls", []), start=1):
+                anchor_date = _resolve_anchor_date(anchor_key, b, hall)
+                release_plan = _add_offset(anchor_date, offset_wd, holidays, ww)
+
+                ideal = hall.get("L3Start")
+                if ideal and buffer_wd:
+                    ideal = date_utils.add_workdays(ideal, -buffer_wd, holidays, workdays_per_week=ww)
+                desired = date_utils.clamp(ideal, hall.get("FitupStart"), hall.get("FitupFinish")) if ideal else None
+
+                release_needed = date_utils.add_workdays(desired, -lead_wd, holidays, workdays_per_week=ww) if (desired and lead_wd) else None
+                release_used = _min_date(release_plan, release_needed) if (release_plan or release_needed) else release_plan or release_needed
+                site_accept = date_utils.add_workdays(release_used, lead_wd, holidays, workdays_per_week=ww) if (release_used and lead_wd) else release_used
+
+                roj = desired
+                if roj and hall.get("FitupStart") and roj < hall["FitupStart"]:
+                    roj = hall["FitupStart"]
+                if site_accept and (roj is None or site_accept > roj):
+                    roj = site_accept
+
                 rows.append({
                     "Building Name": b["building_name"],
-                    "Equipment": f'{item["Equipment"]} (Hall {i})',
+                    "Equipment": f'{item["Equipment"]} (Hall {idx})',
                     "Location": "Hall",
-                    "Required Release/PO": release_h,
-                    "Submittals (days)": submittals_wd,
-                    "Manufacturing (days)": mfg_wd,
-                    "Shipping (days)": ship_wd,
-                    "Site Acceptance": arrival,
-                    "ROJ": roj_h,
-                    
+                    "Release Anchor": anchor_label,
+                    "Release Plan": release_plan,
+                    "Release Needed": release_needed,
+                    "Modeled Release": release_used,
+                    "Lead Time (wd)": lead_wd,
+                    "Site Acceptance": site_accept,
+                    "ROJ Target": desired,
+                    "ROJ": roj,
                 })
     return rows


### PR DESCRIPTION
## Summary
- add sidebar controls for up to five power-delivery tranches and gate each hall’s L3/L5 start through a reusable PowerAllocator so only 12 halls consume a tranche before the next delivery is required
- enrich the RFS output with tranche metadata and wire the new lead-time/back-off driven OFCI equipment data set into the schedule
- replace the static equipment table with client-supplied lead times/back-offs and compute releases via milestone anchors in utils.building

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c9efc6fcfc83238836ef4c81a3826a