### PR TITLE
Allow L3/L4 to use temporary power and highlight urgent PO releases

### DIFF
--- a/components/table.py
+++ b/components/table.py
@@ -1,6 +1,49 @@
+from datetime import date, datetime, timedelta
+
+import pandas as pd
 import streamlit as st
 
-def render_styled_table(df, col_space=110):
+
+def _coerce_date(value):
+  if pd.isna(value):
+    return None
+  if isinstance(value, date) and not isinstance(value, datetime):
+    return value
+  if isinstance(value, (pd.Timestamp, datetime)):
+    return value.date()
+  return None
+
+
+def render_styled_table(df, col_space=110, highlight_release_within_days=None):
   """Render a styled table in Streamlit."""
-  html = df.to_html(index=False, classes="styled-table", col_space=col_space)
+  styler = (
+    df.style
+      .hide(axis="index")
+      .set_table_attributes('class="styled-table"')
+      .set_table_styles([
+        {"selector": "th", "props": [("min-width", f"{col_space}px"), ("white-space", "nowrap")]},
+        {"selector": "td", "props": [("min-width", f"{col_space}px"), ("white-space", "nowrap")]},
+      ])
+  )
+
+  if highlight_release_within_days is not None and not df.empty:
+    today = date.today()
+    window_end = today + timedelta(days=highlight_release_within_days)
+
+    def highlight_release(row):
+      release_dates = [
+        _coerce_date(row.get("Release Plan")),
+        _coerce_date(row.get("Release Needed")),
+      ]
+      release_dates = [d for d in release_dates if d is not None]
+      if not release_dates:
+        return [""] * len(row)
+      earliest_release = min(release_dates)
+      if today <= earliest_release <= window_end:
+        return ["background-color: #fff3cd"] * len(row)
+      return [""] * len(row)
+
+    styler = styler.apply(highlight_release, axis=1)
+
+  html = styler.to_html()
   st.markdown("""<div class="table-container">""" + html + "</div>", unsafe_allow_html=True)

--- a/rfs_calculator_app_mano_default_equipment.py
+++ b/rfs_calculator_app_mano_default_equipment.py
@@ -155,7 +155,7 @@ def schedule_building(build_idx:int, row, power_allocator: PowerAllocator):
 
     def commissioning_power_gate(power_gate):
         if temp_power_allowed and gates["temp_power"]:
-            return max_date(power_gate, gates["temp_power"])
+            return min_date(power_gate, gates["temp_power"])
         return power_gate
 
     def schedule_one_hall(prev_l3_start):
@@ -279,7 +279,7 @@ with tab2:
 with tab3:
     st.subheader("Equipment List")
     # st.dataframe(EQUIP_DF, hide_index=True, use_container_width=True)
-    render_styled_table(EQUIP_DF)
+    render_styled_table(EQUIP_DF, highlight_release_within_days=30)
     st.download_button("Download Equipment (CSV)", EQUIP_DF.to_csv(index=False).encode("utf-8"), "equipment_roj.csv", "text/csv")
 
 st.markdown('<p class="small-muted">Calendar uses United States public holidays • Site Work waits for Notice to Proceed & Land Disturbance Permit • Shell waits for the Building Permit and begins 80 working days after Site Work starts • MEP Yard runs finish-to-finish with Shell • Hall Fitup starts 40 working days after MEP Yard starts • L3 ties to the prior hall (SS+5) and L3/L4 may use Temporary Power • L5 waits for Permanent Power • House equipment ≥ Dry‑In; Hall equipment during Fitup.</p>', unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- allow L3/L4 commissioning to start with the earliest of permanent or temporary power when temporary power is enabled so only L5 waits for the permanent feed
- shade equipment table rows in yellow when their purchase order release window falls within 30 days to flag upcoming actions

## Testing
- python -m compileall components utils rfs_calculator_app_mano_default_equipment.py

------
https://chatgpt.com/codex/tasks/task_e_68ca5ceb62708323a8b26999edc71b19