### PR TITLE
Ensure unique gantt rows and simplify equipment highlighting

### DIFF
--- a/components/table.py
+++ b/components/table.py
@@ -31,12 +31,6 @@ def render_styled_table(df, col_space=110, highlight_release_within_days=None):
     window_end = today + timedelta(days=highlight_release_within_days)
 
     def highlight_release(row):
-      flag = row.get("Release Flag", "")
-      if flag == "🔴":
-        return ["background-color: #f8d7da"] * len(row)
-      if flag == "🟡":
-        return ["background-color: #fff3cd"] * len(row)
-
       release_dates = [
         _coerce_date(row.get("Release Plan")),
         _coerce_date(row.get("Release Needed")),

--- a/utils/building.py
+++ b/utils/building.py
@@ -90,20 +90,6 @@ def _roj_status(site_accept, roj_target, roj):
     return "🔴"
 
 
-def _release_flag(*release_dates):
-    today = date_utils.date.today()
-    window_end = today + date_utils.timedelta(days=30)
-    valid_dates = [d for d in release_dates if d]
-    if not valid_dates:
-        return ""
-    earliest = min(valid_dates)
-    if earliest < today:
-        return "🔴"
-    if today <= earliest <= window_end:
-        return "🟡"
-    return ""
-
-
 def get_modeled_equipment_rows(b, ww, holidays):
     rows = []
     first_hall = b["halls"][0] if b.get("halls") else None
@@ -140,7 +126,6 @@ def get_modeled_equipment_rows(b, ww, holidays):
                 "Location": "House",
                 "Release Plan": release_plan,
                 "Release Needed": release_needed,
-                "Release Flag": _release_flag(release_plan, release_needed),
                 "Lead Time (weeks)": _lead_time_weeks(lead_wd),
                 "Site Acceptance": site_accept,
                 "ROJ Target": desired,
@@ -173,7 +158,6 @@ def get_modeled_equipment_rows(b, ww, holidays):
                     "Location": "Hall",
                     "Release Plan": release_plan,
                     "Release Needed": release_needed,
-                    "Release Flag": _release_flag(release_plan, release_needed),
                     "Lead Time (weeks)": _lead_time_weeks(lead_wd),
                     "Site Acceptance": site_accept,
                     "ROJ Target": desired,


### PR DESCRIPTION
## Summary
- ensure each Gantt entry renders on its own row with descriptive labels and adjust milestone placement
- simplify the equipment table by relying on date-based highlighting instead of a release flag column

## Testing
- python -m compileall components/chart.py components/table.py utils/building.py

------
https://chatgpt.com/codex/tasks/task_e_68ca6af6dba48323821272f3a53d1d18