### PR TITLE
Ensure gantt chart shows unique activities ordered by earliest finish

### DIFF
--- a/components/chart.py
+++ b/components/chart.py
@@ -48,7 +48,7 @@ def render_gantt(gdf, milestones=None):
         linewidth=1,
         linecolor=colors.MANO_BLUE,
         categoryorder="array",
-        categoryarray=category_order[::-1],
+        categoryarray=category_order,
     )
     fig.update_traces(width=0.6)
     fig.update_layout(

--- a/rfs_calculator_app_mano_default_equipment.py
+++ b/rfs_calculator_app_mano_default_equipment.py
@@ -300,7 +300,10 @@ with tab2:
             })
     gdf = pd.DataFrame(gantt_rows)
     if not gdf.empty:
-        gdf = gdf.sort_values(by=["Finish", "Start"], na_position="last", kind="mergesort").reset_index(drop=True)
+        gdf = gdf.sort_values(
+            by=["Finish", "Start"], na_position="last", kind="mergesort"
+        )
+        gdf = gdf[~gdf["Task"].duplicated(keep="first")].reset_index(drop=True)
     milestone_df = pd.DataFrame(milestone_rows) if milestone_rows else None
     render_gantt(gdf, milestone_df)
 


### PR DESCRIPTION
## Summary
- sort and de-duplicate gantt activity rows so each task is rendered only once
- keep the activity order when configuring the y-axis so earliest-finishing work appears at the top of the chart

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ca9cfb8be483239364d4d2703db96b