### PR TITLE
Add status icons for equipment release readiness

### DIFF
--- a/components/table.py
+++ b/components/table.py
@@ -16,8 +16,28 @@ def _coerce_date(value):
 
 def render_styled_table(df, col_space=110, highlight_release_within_days=None):
   """Render a styled table in Streamlit."""
+  display_df = df.copy()
+
+  status_icon_map = {
+    "Overdue": "🔴",
+    "At Risk": "🟡",
+    "On Track": "🟢",
+  }
+  status_color_map = {
+    "Overdue": "#d62828",
+    "At Risk": "#f4a261",
+    "On Track": "#2a9d8f",
+  }
+
+  if "Status" in display_df.columns:
+    display_df["Status"] = display_df["Status"].map(
+      lambda s: f"{status_icon_map.get(s, '')} {s}".strip()
+      if isinstance(s, str) and s
+      else s
+    )
+
   styler = (
-    df.style
+    display_df.style
       .hide(axis="index")
       .set_table_attributes('class="styled-table"')
       .set_table_styles([
@@ -26,7 +46,7 @@ def render_styled_table(df, col_space=110, highlight_release_within_days=None):
       ])
   )
 
-  if highlight_release_within_days is not None and not df.empty:
+  if highlight_release_within_days is not None and not display_df.empty:
     today = date.today()
     window_end = today + timedelta(days=highlight_release_within_days)
 
@@ -46,6 +66,19 @@ def render_styled_table(df, col_space=110, highlight_release_within_days=None):
       return [""] * len(row)
 
     styler = styler.apply(highlight_release, axis=1)
+
+  if "Status" in display_df.columns:
+    def style_status(val):
+      if isinstance(val, str):
+        if val.startswith("🔴"):
+          return f"color: {status_color_map['Overdue']}; font-weight: 600;"
+        if val.startswith("🟡"):
+          return f"color: {status_color_map['At Risk']}; font-weight: 600;"
+        if val.startswith("🟢"):
+          return f"color: {status_color_map['On Track']}; font-weight: 600;"
+      return ""
+
+    styler = styler.applymap(style_status, subset=["Status"])
 
   html = styler.to_html()
   st.markdown("""<div class="table-container">""" + html + "</div>", unsafe_allow_html=True)

--- a/rfs_calculator_app_mano_default_equipment.py
+++ b/rfs_calculator_app_mano_default_equipment.py
@@ -319,8 +319,9 @@ with tab3:
     st.markdown(
         """
         <div class="equipment-legend">
-          <span class="legend-item"><span class="legend-swatch legend-overdue"></span>Release date past due</span>
-          <span class="legend-item"><span class="legend-swatch legend-upcoming"></span>Release needed within 30 days</span>
+          <span class="legend-item">🔴 Overdue</span>
+          <span class="legend-item">🟡 At Risk</span>
+          <span class="legend-item">🟢 On Track</span>
         </div>
         """,
         unsafe_allow_html=True,

--- a/utils/building.py
+++ b/utils/building.py
@@ -1,4 +1,5 @@
 import math
+from datetime import date, datetime
 
 import utils.date as date_utils
 import data.equipment as equipment
@@ -74,6 +75,21 @@ def _lead_time_weeks(lead_wd):
     return math.ceil(lead_wd / 5)
 
 
+def _equipment_status(release_needed):
+    if release_needed is None:
+        return "On Track"
+
+    if isinstance(release_needed, datetime):
+        release_needed = release_needed.date()
+
+    today = date.today()
+    if release_needed < today:
+        return "Overdue"
+    if (release_needed - today).days <= 30:
+        return "At Risk"
+    return "On Track"
+
+
 def _roj_status(site_accept, roj_target, roj):
     if not site_accept:
         return ""
@@ -126,6 +142,7 @@ def get_modeled_equipment_rows(b, ww, holidays):
                 "Location": "House",
                 "Release Plan": release_plan,
                 "Release Needed": release_needed,
+                "Status": _equipment_status(release_needed),
                 "Lead Time (weeks)": _lead_time_weeks(lead_wd),
                 "Site Acceptance": site_accept,
                 "ROJ Target": desired,
@@ -158,6 +175,7 @@ def get_modeled_equipment_rows(b, ww, holidays):
                     "Location": "Hall",
                     "Release Plan": release_plan,
                     "Release Needed": release_needed,
+                    "Status": _equipment_status(release_needed),
                     "Lead Time (weeks)": _lead_time_weeks(lead_wd),
                     "Site Acceptance": site_accept,
                     "ROJ Target": desired,


### PR DESCRIPTION
## Summary
- classify equipment release status as Overdue, At Risk, or On Track when building the modeled equipment rows
- show colored status indicators within the equipment table and refresh the legend copy to match the new badges

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d3174528848323bd65fdce02fb106f