### PR TITLE
Remove release plan calculations from equipment modeling

### DIFF
--- a/components/table.py
+++ b/components/table.py
@@ -51,17 +51,12 @@ def render_styled_table(df, col_space=110, highlight_release_within_days=None):
     window_end = today + timedelta(days=highlight_release_within_days)
 
     def highlight_release(row):
-      release_dates = [
-        _coerce_date(row.get("Release Plan")),
-        _coerce_date(row.get("Release Needed")),
-      ]
-      release_dates = [d for d in release_dates if d is not None]
-      if not release_dates:
+      release_date = _coerce_date(row.get("Release Needed"))
+      if release_date is None:
         return [""] * len(row)
-      earliest_release = min(release_dates)
-      if earliest_release < today:
+      if release_date < today:
         return ["background-color: #f8d7da"] * len(row)
-      if earliest_release <= window_end:
+      if release_date <= window_end:
         return ["background-color: #fff3cd"] * len(row)
       return [""] * len(row)
 

--- a/data/equipment.py
+++ b/data/equipment.py
@@ -1,54 +1,41 @@
 # ======================= Client-specific OFCI equipment =======================
-# Each entry captures the assumed lead time in working days along with the
-# release "back off" (how many working days away from the anchor milestone the
-# PO should be placed).  Buffers represent the desired cushion ahead of L3.
+# Each entry captures the assumed lead time in working days. Buffers represent
+# the desired cushion ahead of L3.
 RAW_EQUIPMENT = [
     {
         "Equipment": "Generators",
         "scope": "house",
         "lead_time_wd": 320,
         "buffer_wd_before_L3": 30,
-        "release_anchor": "ntp",
-        "release_offset_wd": 150,
     },
     {
         "Equipment": "Utility Switchgear",
         "scope": "house",
         "lead_time_wd": 240,
         "buffer_wd_before_L3": 30,
-        "release_anchor": "ntp",
-        "release_offset_wd": 200,
     },
     {
         "Equipment": "UPS",
         "scope": "hall",
         "lead_time_wd": 270,
         "buffer_wd_before_L3": 20,
-        "release_anchor": "bp",
-        "release_offset_wd": 105,
     },
     {
         "Equipment": "PDU",
         "scope": "hall",
         "lead_time_wd": 225,
         "buffer_wd_before_L3": 20,
-        "release_anchor": "fitup_start",
-        "release_offset_wd": -60,
     },
     {
         "Equipment": "CRAC",
         "scope": "hall",
         "lead_time_wd": 210,
         "buffer_wd_before_L3": 20,
-        "release_anchor": "fitup_start",
-        "release_offset_wd": -60,
     },
     {
         "Equipment": "BMS",
         "scope": "hall",
         "lead_time_wd": 180,
         "buffer_wd_before_L3": 25,
-        "release_anchor": "fitup_start",
-        "release_offset_wd": -90,
     },
 ]

--- a/utils/building.py
+++ b/utils/building.py
@@ -9,65 +9,6 @@ def _max_date(*dates):
     valid = [d for d in dates if d is not None]
     return max(valid) if valid else None
 
-
-def _min_date(*dates):
-    valid = [d for d in dates if d is not None]
-    return min(valid) if valid else None
-
-
-def _resolve_anchor_date(anchor, building, hall):
-    if not anchor:
-        return None
-    anchor = anchor.lower()
-    gates = building.get("gates", {}) if isinstance(building.get("gates"), dict) else {}
-
-    if anchor == "ntp":
-        return gates.get("ntp")
-    if anchor == "ldp":
-        return gates.get("ldp")
-    if anchor == "bp":
-        return gates.get("bp")
-    if anchor in ("perm_power", "permanent_power"):
-        return building.get("perm_power")
-    if anchor == "dryin":
-        return building.get("dryin_date")
-    if anchor == "shell_start":
-        return building.get("shell_start")
-    if anchor == "shell_finish":
-        return building.get("shell_finish")
-    if anchor == "civil_start":
-        return building.get("civil_start")
-    if anchor == "mep_start":
-        return building.get("mep_start")
-    if anchor == "mep_finish":
-        return building.get("mep_finish")
-    if anchor in ("fitup_start", "hall_fit_start"):
-        if hall:
-            return hall.get("FitupStart")
-        return building.get("halls", [{}])[0].get("FitupStart") if building.get("halls") else None
-    if anchor in ("fitup_finish", "hall_fit_finish"):
-        if hall:
-            return hall.get("FitupFinish")
-        return building.get("halls", [{}])[0].get("FitupFinish") if building.get("halls") else None
-    if anchor in ("l3_start", "hall_l3_start"):
-        if hall:
-            return hall.get("L3Start")
-        return building.get("halls", [{}])[0].get("L3Start") if building.get("halls") else None
-    if anchor == "power_gate" and hall:
-        return hall.get("PowerGate")
-    if anchor == "power_delivery" and hall:
-        return hall.get("PowerDeliveryDate")
-    return None
-
-
-def _add_offset(base, offset, holidays, ww):
-    if base is None:
-        return None
-    if offset in (None, 0):
-        return base
-    return date_utils.add_workdays(base, int(offset), holidays, workdays_per_week=ww)
-
-
 # ======================= Procurement model (lead time + back off) =======================
 def _lead_time_weeks(lead_wd):
     if lead_wd <= 0:
@@ -97,12 +38,7 @@ def get_modeled_equipment_rows(b, ww, holidays):
     for item in equipment.RAW_EQUIPMENT:
         lead_wd = int(item.get("lead_time_wd") or 0)
         buffer_wd = int(item.get("buffer_wd_before_L3") or 0)
-        offset_wd = item.get("release_offset_wd")
-        anchor_key = item.get("release_anchor")
         if item["scope"] == "house":
-            anchor_date = _resolve_anchor_date(anchor_key, b, None)
-            release_plan = _add_offset(anchor_date, offset_wd, holidays, ww)
-
             desired = None
             if first_hall and first_hall.get("L3Start"):
                 ideal = first_hall["L3Start"]
@@ -111,8 +47,8 @@ def get_modeled_equipment_rows(b, ww, holidays):
                 desired = date_utils.clamp(ideal, b.get("dryin_date"), None)
 
             release_needed = date_utils.add_workdays(desired, -lead_wd, holidays, workdays_per_week=ww) if (desired and lead_wd) else None
-            release_used = _min_date(release_plan, release_needed) if (release_plan or release_needed) else release_plan or release_needed
-            site_accept = date_utils.add_workdays(release_used, lead_wd, holidays, workdays_per_week=ww) if (release_used and lead_wd) else release_used
+            release_date = release_needed
+            site_accept = date_utils.add_workdays(release_date, lead_wd, holidays, workdays_per_week=ww) if (release_date and lead_wd) else release_date
 
             roj = desired
             if site_accept and (roj is None or site_accept > roj):
@@ -124,7 +60,6 @@ def get_modeled_equipment_rows(b, ww, holidays):
                 "Building Name": b["building_name"],
                 "Equipment": item["Equipment"],
                 "Location": "House",
-                "Release Plan": release_plan,
                 "Release Needed": release_needed,
                 "Status": _equipment_status(release_needed),
                 "Lead Time (weeks)": _lead_time_weeks(lead_wd),
@@ -134,17 +69,14 @@ def get_modeled_equipment_rows(b, ww, holidays):
             })
         else:
             for idx, hall in enumerate(b.get("halls", []), start=1):
-                anchor_date = _resolve_anchor_date(anchor_key, b, hall)
-                release_plan = _add_offset(anchor_date, offset_wd, holidays, ww)
-
                 ideal = hall.get("L3Start")
                 if ideal and buffer_wd:
                     ideal = date_utils.add_workdays(ideal, -buffer_wd, holidays, workdays_per_week=ww)
                 desired = date_utils.clamp(ideal, hall.get("FitupStart"), hall.get("FitupFinish")) if ideal else None
 
                 release_needed = date_utils.add_workdays(desired, -lead_wd, holidays, workdays_per_week=ww) if (desired and lead_wd) else None
-                release_used = _min_date(release_plan, release_needed) if (release_plan or release_needed) else release_plan or release_needed
-                site_accept = date_utils.add_workdays(release_used, lead_wd, holidays, workdays_per_week=ww) if (release_used and lead_wd) else release_used
+                release_date = release_needed
+                site_accept = date_utils.add_workdays(release_date, lead_wd, holidays, workdays_per_week=ww) if (release_date and lead_wd) else release_date
 
                 roj = desired
                 if roj and hall.get("FitupStart") and roj < hall["FitupStart"]:
@@ -156,7 +88,6 @@ def get_modeled_equipment_rows(b, ww, holidays):
                     "Building Name": b["building_name"],
                     "Equipment": f'{item["Equipment"]} (Hall {idx})',
                     "Location": "Hall",
-                    "Release Plan": release_plan,
                     "Release Needed": release_needed,
                     "Status": _equipment_status(release_needed),
                     "Lead Time (weeks)": _lead_time_weeks(lead_wd),


### PR DESCRIPTION
## Summary
- remove the release plan calculations from the equipment modeling logic and rely solely on release-needed dates
- update the equipment table highlighting to track upcoming releases without the release plan column
- tidy the equipment seed data comments after removing release offsets

## Testing
- python -m compileall components utils data rfs_calculator_app_mano_default_equipment.py
- python -m compileall utils/building.py

------
https://chatgpt.com/codex/tasks/task_e_68d31ad48d8c8323a89e97bb3d4cabfb